### PR TITLE
Revert "add pre build command"

### DIFF
--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -18,5 +18,4 @@ jobs:
             ${{ runner.os }}-gems-
       - uses: helaili/jekyll-action@v2
         with:
-          pre_build_commands: git config --global http.version HTTP/1.1; apk fetch git-lfs;
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Reverts d-otis/jp-jekyll#11 as there's indication this has been fixed [here](https://github.com/orgs/community/discussions/55820#discussioncomment-6022063)