### PR TITLE
fix-d-bot-config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,7 +6,7 @@
 version: 2
 updates:
   - package-ecosystem: "bundler" # See documentation for possible values
-    directory: "../" # Location of package manifests
+    directory: "/" # Location of package manifests
     schedule:
       interval: "daily"
     versioning-strategy: lockfile-only


### PR DESCRIPTION
# Problem/Description
New d-bot config was failing with this error:
<img width="653" alt="Screenshot 2023-10-05 at 17 11 28" src="https://github.com/d-otis/jp-jekyll/assets/32817606/a03c64fc-1295-47f9-b376-191d6df2895c">

Then being directed to the [documentation](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#directory)

I feel like the directory was previous `"/"` and nothing happened re: updates, but maybe I'm conflating the fact that no updates were released with the directory value 🤷🏻‍♂️ 

# Solution
 Follow the documentation to correct the directory value.

# Future Work